### PR TITLE
Retain false

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    checkout_sdk (0.2.0)
+    checkout_sdk (0.2.1)
       excon (>= 0.66, < 0.72)
       multi_json (~> 1.0)
 
@@ -10,7 +10,7 @@ GEM
   specs:
     coderay (1.1.2)
     diff-lcs (1.3)
-    excon (0.71.0)
+    excon (0.71.1)
     method_source (0.9.2)
     multi_json (1.14.1)
     pry (0.11.3)

--- a/README.md
+++ b/README.md
@@ -113,6 +113,20 @@ response.local_port     # => 51601
 response.local_address  # => "..."
 ```
 
+#### NB: Using boolean/falsey values
+```ruby
+# `nil` or empty strings
+payment_request_source.capture = nil
+payment_request_source.capture = ""
+# will be stripped from API call
+
+# but `false`, or 0
+payment_request_source.capture = false
+payment_request_source.capture = 0
+# are retained and sent in request
+```
+See [api_resource_spec](https://github.com/checkout/checkout-sdk-ruby/blob/master/spec/checkout_sdk/api_resource_spec.rb#L10-L24) for details
+
 ## Tests
 
     $ rspec

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CheckoutSdk
 
-You are reading documentation for version: 0.2.0
+You are reading documentation for version: 0.2.1
 
 ## Installation
 

--- a/lib/checkout_sdk/api_resource.rb
+++ b/lib/checkout_sdk/api_resource.rb
@@ -68,7 +68,7 @@ class CheckoutSdk::ApiResource
 
   def delete_blank(data_hash)
     data_hash.delete_if do |k, v|
-      (v.respond_to?(:empty?) ? v.empty? : !v) or v.instance_of?(Hash) && delete_blank(v).empty?
+      (v.respond_to?(:empty?) ? v.empty? : v.nil?) or v.instance_of?(Hash) && delete_blank(v).empty?
     end
   end
 end

--- a/lib/checkout_sdk/version.rb
+++ b/lib/checkout_sdk/version.rb
@@ -1,3 +1,3 @@
 module CheckoutSdk
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end

--- a/spec/checkout_sdk/api_resource_spec.rb
+++ b/spec/checkout_sdk/api_resource_spec.rb
@@ -9,13 +9,13 @@ RSpec.describe CheckoutSdk::ApiResource do
 
   describe "#request_payment" do
     let(:payment_request_source) { CheckoutSdk::PaymentRequestSource.new }
-    let(:data) { { mock: true } }
+    let(:data) { { mock: true, mockfalse: false, mockzero: 0, mocknil: nil, mockempty: "" } }
 
     it "sends a POST request with correct params" do
       allow(payment_request_source).to receive(:data).and_return(data)
 
       expect(api_resource.checkout_connection).to receive(:post)
-        .with({ body:"{\"mock\":true}",
+        .with({ body:"{\"mock\":true,\"mockfalse\":false,\"mockzero\":0}",
                 headers:{"Authorization"=>"sk_test", "Content-Type"=>"application/json"},
                 path:"/payments" })
 


### PR DESCRIPTION
This PR enables bareword `false` values to be sent in the json payload to the checkout.com API. Previously they would get stripped as blank/falsey values.