### PR TITLE
Allow persistent option to be configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ CheckoutSdk.configure do |config|
   config.secret_key = ENV['SECRET_KEY']
   config.public_key = ENV['PUBLIC_KEY']
   config.base_url   = ENV['BASE_URL']
+  config.persistent = true|false # default: true
 end
 ```
 

--- a/lib/checkout_sdk/api_resource.rb
+++ b/lib/checkout_sdk/api_resource.rb
@@ -5,7 +5,10 @@ class CheckoutSdk::ApiResource
   attr_reader :checkout_connection
 
   def initialize
-    @checkout_connection = Excon.new("#{CheckoutSdk.configuration.base_url}", persistent: true)
+    @checkout_connection = Excon.new(
+      "#{CheckoutSdk.configuration.base_url}",
+      persistent: CheckoutSdk.configuration.persistent
+    )
   end
 
   def request_payment(data_object)

--- a/lib/checkout_sdk/configuration.rb
+++ b/lib/checkout_sdk/configuration.rb
@@ -1,9 +1,10 @@
 class CheckoutSdk::Configuration
-  attr_accessor :secret_key, :public_key, :base_url
+  attr_accessor :secret_key, :public_key, :base_url, :persistent
 
   def initialize
     @secret_key = nil
     @public_key = nil
     @base_url = nil
+    @persistent = true
   end
 end

--- a/lib/checkout_sdk/version.rb
+++ b/lib/checkout_sdk/version.rb
@@ -1,3 +1,3 @@
 module CheckoutSdk
-  VERSION = "0.2.2"
+  VERSION = "0.3.0"
 end

--- a/spec/checkout_sdk_spec.rb
+++ b/spec/checkout_sdk_spec.rb
@@ -4,4 +4,18 @@ RSpec.describe CheckoutSdk do
   it "has a version number" do
     expect(CheckoutSdk::VERSION).not_to be nil
   end
+
+  describe "Config persistent" do
+    it "has a default persistent option" do
+      expect(CheckoutSdk.configuration.persistent).to be_truthy
+    end
+
+    it "allows you to change the persistent option" do
+      CheckoutSdk.configure do |config|
+        config.persistent = false
+      end
+
+      expect(CheckoutSdk.configuration.persistent).to be_falsy
+    end
+  end
 end


### PR DESCRIPTION
We are using Kubernetes so can not guarantee a given hostname will keep its IP so therefore the current `config.persistent = true` will not work reliably for us.

This PR allows this option to be configurable.