### PR TITLE
bump excon (>= 0.66, <= 0.88.0) and bundler (~>2)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    checkout_sdk (0.2.2)
-      excon (>= 0.66, < 0.79)
+    checkout_sdk (0.3.2)
+      excon (>= 0.66, <= 0.88.0)
       multi_json (~> 1.0)
 
 GEM
@@ -10,7 +10,7 @@ GEM
   specs:
     coderay (1.1.3)
     diff-lcs (1.4.4)
-    excon (0.78.1)
+    excon (0.88.0)
     method_source (0.9.2)
     multi_json (1.15.0)
     pry (0.11.3)
@@ -35,11 +35,11 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.16)
+  bundler (~> 2.0)
   checkout_sdk!
   pry (~> 0.11.3)
   rake (~> 10.0)
   rspec (~> 3.5)
 
 BUNDLED WITH
-   1.17.3
+   2.2.31

--- a/checkout_sdk.gemspec
+++ b/checkout_sdk.gemspec
@@ -15,10 +15,10 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.license       = "MIT"
 
-  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.5"
   spec.add_development_dependency "pry",  "~> 0.11.3"
   spec.add_dependency "multi_json", '~> 1.0'
-  spec.add_dependency "excon", ">= 0.66", "< 0.79"
+  spec.add_dependency "excon", ">= 0.66", "<= 0.88.0"
 end


### PR DESCRIPTION
The version of `excon` is out of date. The lib is currently using `0.78.1` which was released `December 04, 2020`. This PR bumps the gem so it can be more compatible with code bases using later versions of the lib.

I have also bumped `bundler` as that was still using `1.*`