### PR TITLE
Add processing_channel_id to PaymentRequestSource

### DIFF
--- a/lib/checkout_sdk/data/payment_request_source.rb
+++ b/lib/checkout_sdk/data/payment_request_source.rb
@@ -10,7 +10,7 @@ class CheckoutSdk::PaymentRequestSource
                 :success_url, :failure_url, :payment_ip, :recipient_dob, :recipient_account_number,
                 :recipient_zip, :recipient_last_name, :processing_mid, :metadata, :cvv, :id, :card_number,
                 :card_expiry_month, :card_expiry_year, :card_name, :card_cvv, :card_stored, :customer_id,
-                :customer_email, :merchant_initiated
+                :customer_email, :merchant_initiated, :processing_channel_id
 
   def data
     { source: source(type),
@@ -70,7 +70,11 @@ class CheckoutSdk::PaymentRequestSource
         mid: processing_mid
       },
       metadata: metadata
-    }
+    }.tap do |result|
+      if processing_channel_id
+        result[:processing_channel_id] = processing_channel_id
+      end
+    end
   end
 
   private

--- a/spec/checkout_sdk/data/payment_request_source_spec.rb
+++ b/spec/checkout_sdk/data/payment_request_source_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe CheckoutSdk::PaymentRequestSource do
   let(:token) { "tok_4gzeau5o2uqubbk6fufs3m7p54" }
   let(:customer_id) { "12345678" }
   let(:customer_email) { "elmo@friends.sesame" }
+  let(:processing_channel_id) { "pc_agaeauao2uqabbk6fafs3a7pa4" }
   let(:expected_card_source) {
     {
       type: type,
@@ -120,6 +121,20 @@ RSpec.describe CheckoutSdk::PaymentRequestSource do
         payment_request_source.type = "customer"
 
         expect(get_keys(payment_request_source.data[:source])).to eql(get_keys(expected_customer_source))
+      end
+    end
+
+    it "doesn't contain processing_channel_id if not set" do
+      expect(payment_request_source.data.key?(:processing_channel_id)).to be_falsey
+    end
+
+    context "processing channel id set" do
+      before do
+        payment_request_source.processing_channel_id = processing_channel_id
+      end
+
+      it "adds procesing_channel_id to the request if set" do
+        expect(payment_request_source.data[:processing_channel_id]).to eql(processing_channel_id)
       end
     end
   end


### PR DESCRIPTION
Per updates in the documentation: 

- https://www.checkout.com/docs/four/search?query=processing_channel_id&page=1
- https://www.checkout.com/docs/four/marketplaces/quick-start-full
- https://api-reference.checkout.com/preview/crusoe/#operation/requestAPaymentOrPayout

