### PR TITLE
Added support for redirect responses for http client.

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ also need to specify the custom `http client` for `multipart requests`:
 http_client = Faraday.new do |conn|
   conn.options.timeout = 10
   conn.proxy "http://localhost:8080"
+  conn.response :raise_error
 end
 
 multipart_client = Faraday.new do |f|
@@ -181,6 +182,25 @@ api = CheckoutSdk.builder
                  .with_environment(CheckoutSdk::Environment.sandbox)
                  .with_http_client(http_client)
                  .with_multipart_http_client(multipart_client)
+                 .build
+```
+
+If you want to use your own `http_client` and wants to use `Reports` module, the `get_report_file` function follows a redirect URL from Checkout, 
+Ruby SDK uses `faraday-follow-redirects` which is an [open source](https://github.com/tisba/faraday-follow-redirects) solution that came after Faraday 2.0 deprecation, 
+you must add it otherwise Ruby SDK will not be able to download the contents file, or provide your custom redirect adapter.
+
+```ruby
+http_client = Faraday.new do |f|
+  f.response :follow_redirects
+  f.response :raise_error
+end
+
+api = CheckoutSdk.builder
+                 .static_keys
+                 .with_secret_key('secret_key')
+                 .with_public_key('public_key') # optional, only required for operations related with tokens
+                 .with_environment(CheckoutSdk::Environment.sandbox)
+                 .with_http_client(http_client)
                  .build
 ```
 

--- a/checkout_sdk.gemspec
+++ b/checkout_sdk.gemspec
@@ -33,5 +33,6 @@ sellers and service providers."
   spec.add_development_dependency 'rubocop', '~> 1.36.0'
   spec.add_dependency 'faraday', '>= 2.0.0'
   spec.add_dependency 'faraday-multipart', '~> 1.0.4'
+  spec.add_dependency 'faraday-follow_redirects', '~> 0.3.0'
   spec.add_dependency 'mime-types', '~> 3.0'
 end

--- a/lib/checkout_sdk.rb
+++ b/lib/checkout_sdk.rb
@@ -6,6 +6,7 @@ require 'json'
 require 'faraday'
 require 'faraday/multipart'
 require 'faraday/net_http'
+require 'faraday/follow_redirects'
 require 'mime/types'
 require 'logger'
 

--- a/lib/checkout_sdk/checkout_utils.rb
+++ b/lib/checkout_sdk/checkout_utils.rb
@@ -32,6 +32,7 @@ module CheckoutSdk
     # @return [Faraday::Connection]
     def self.build_default_client
       Faraday.new do |f|
+        f.response :follow_redirects
         f.response :raise_error
       end
     end

--- a/lib/checkout_sdk/reports/reports_client.rb
+++ b/lib/checkout_sdk/reports/reports_client.rb
@@ -21,6 +21,12 @@ module CheckoutSdk
       def get_report_details(report_id)
         api_client.invoke_get(build_path(REPORTS, report_id), sdk_authorization)
       end
+
+      # @param [String] report_id
+      # @param [String] file_id
+      def get_report_file(report_id, file_id)
+        api_client.invoke_get(build_path(REPORTS, report_id, FILES, file_id), sdk_authorization)
+      end
     end
   end
 end

--- a/spec/checkout_sdk/reports/reports_integration_spec.rb
+++ b/spec/checkout_sdk/reports/reports_integration_spec.rb
@@ -61,4 +61,21 @@ RSpec.describe CheckoutSdk::Reports do
       end
     end
   end
+
+  describe '.get_report_file' do
+    context 'when requesting report file' do
+      subject(:report) {
+        response = default_sdk.reports.get_all_reports @query
+        assert_response response, %w[data]
+        response.data[0]
+      }
+      it 'should retrieve report file contents' do
+        response = default_sdk.reports.get_report_file report.id, report.files[0].id
+        expect(response).not_to be_nil
+        expect(response.contents).not_to be_nil
+        expect(response.metadata.status_code).to eq 200
+      end
+
+    end
+  end
 end


### PR DESCRIPTION
Added a new dependency `faraday-follow_redirects` to support redirect responses for Faraday 2.0, given that `Faraday Middleware` is deprecated