### PR TITLE
Fixes logger builder to return builder instance

### DIFF
--- a/lib/checkout_sdk/abstract_checkout_sdk_builder.rb
+++ b/lib/checkout_sdk/abstract_checkout_sdk_builder.rb
@@ -30,6 +30,7 @@ module CheckoutSdk
 
     def with_logger(logger)
       @logger = logger
+      self
     end
 
     def build


### PR DESCRIPTION
Fix for issue https://github.com/checkout/checkout-sdk-ruby/issues/98