### PR TITLE
Add reverse_payment

### DIFF
--- a/lib/checkout_sdk/payments/base_payments_client.rb
+++ b/lib/checkout_sdk/payments/base_payments_client.rb
@@ -41,6 +41,16 @@ module CheckoutSdk
                                void_request,
                                idempotency_key)
       end
+
+      # @param [String] payment_id
+      # @param [Hash, ReverseRequest] reverse_request
+      # @param [String, nil] idempotency_key
+      def reverse_payment(payment_id, reverse_request = nil, idempotency_key = nil)
+        api_client.invoke_post(build_path(PAYMENTS_PATH, payment_id, 'reversals'),
+                               sdk_authorization,
+                               reverse_request,
+                               idempotency_key)
+      end
     end
   end
 end

--- a/lib/checkout_sdk/payments/reverse_request.rb
+++ b/lib/checkout_sdk/payments/reverse_request.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module CheckoutSdk
+  module Payments
+    # @!attribute reference
+    #   @return [String]
+    # @!attribute metadata
+    #   @return [Hash{String => Object}]
+    class ReverseRequest
+      attr_accessor :reference,
+                    :metadata
+    end
+  end
+end

--- a/spec/checkout_sdk/payments/reverse_payments_integration_spec.rb
+++ b/spec/checkout_sdk/payments/reverse_payments_integration_spec.rb
@@ -1,0 +1,35 @@
+RSpec.describe CheckoutSdk::Payments do
+  include PaymentsHelper
+
+  describe '.reverse_payment' do
+    context 'when attempt payment' do
+      it 'reverse payment' do
+        payment_response = make_card_payment
+
+        request = CheckoutSdk::Payments::ReverseRequest.new
+        request.reference = SecureRandom.uuid
+
+        response = default_sdk.payments.reverse_payment(payment_response.id, request)
+        assert_response(response, %w[reference
+                                     action_id
+                                     _links])
+      end
+
+      it 'reverse payment idempotent' do
+        payment_response = make_card_payment
+
+        request = CheckoutSdk::Payments::ReverseRequest.new
+
+        request.reference = SecureRandom.uuid
+        idempotency_key = new_idempotency_key
+
+        proc = lambda { default_sdk.payments.reverse_payment(payment_response.id, request, idempotency_key) }
+        proc2 = lambda { default_sdk.payments.reverse_payment(payment_response.id, request, idempotency_key) }
+
+        reverse_response_1 = retriable(proc)
+        reverse_response_2 = retriable(proc2)
+        expect(reverse_response_1.action_id).to eq(reverse_response_2.action_id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Missing support for reverse_payment.
See https://api-reference.checkout.com/#tag/Payments/paths/~1payments~1%7Bid%7D~1reversals/post

Resolves https://github.com/checkout/checkout-sdk-ruby/issues/141