### PR TITLE
feat: add ForwardClient and integrate with CheckoutApi

### DIFF
--- a/lib/checkout_sdk.rb
+++ b/lib/checkout_sdk.rb
@@ -67,6 +67,7 @@ require 'checkout_sdk/transfers/transfers'
 require 'checkout_sdk/metadata/metadata'
 require 'checkout_sdk/financial/financial'
 require 'checkout_sdk/issuing/issuing'
+require 'checkout_sdk/forward/forward'
 
 # Checkout modules (previous)
 require 'checkout_sdk/sources/sources'

--- a/lib/checkout_sdk/checkout_api.rb
+++ b/lib/checkout_sdk/checkout_api.rb
@@ -43,6 +43,8 @@ module CheckoutSdk
   #   @return [CheckoutSdk::Payments::PaymentContextsClient]
   # @!attribute payment_sessions
   #   @return [CheckoutSdk::Payments::PaymentSessionsClient]
+  # @!attribute forward
+  #   @return [CheckoutSdk::Forward::ForwardClient]
   class CheckoutApi
     attr_reader :customers,
                 :disputes,
@@ -64,7 +66,8 @@ module CheckoutSdk
                 :financial,
                 :issuing,
                 :contexts,
-                :payment_sessions
+                :payment_sessions,
+                :forward
 
     # @param [CheckoutConfiguration] configuration
     def initialize(configuration)
@@ -90,6 +93,7 @@ module CheckoutSdk
       @issuing = CheckoutSdk::Issuing::IssuingClient.new api_client, configuration
       @contexts = CheckoutSdk::Payments::PaymentContextsClient.new api_client, configuration
       @payment_sessions = CheckoutSdk::Payments::PaymentSessionsClient.new api_client, configuration
+      @forward = CheckoutSdk::Forward::ForwardClient.new(api_client, configuration)
     end
 
     private

--- a/lib/checkout_sdk/forward/forward.rb
+++ b/lib/checkout_sdk/forward/forward.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require 'checkout_sdk/forward/forward_client'

--- a/lib/checkout_sdk/forward/forward_client.rb
+++ b/lib/checkout_sdk/forward/forward_client.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module CheckoutSdk
+  module Forward
+    class ForwardClient < Client
+      FORWARD = 'forward'
+      private_constant :FORWARD
+
+      # @param [ApiClient] api_client
+      # @param [CheckoutConfiguration] configuration
+      def initialize(api_client, configuration)
+        super(api_client, configuration, CheckoutSdk::AuthorizationType::SECRET_KEY_OR_OAUTH)
+      end
+
+      # @param [Hash] forward_request
+      def forward_request(forward_request)
+        api_client.invoke_post(build_path(FORWARD), sdk_authorization, forward_request)
+      end
+
+      # @param [String] forward_id
+      def get(forward_id)
+        api_client.invoke_get(build_path(FORWARD, forward_id), sdk_authorization)
+      end
+    end
+  end
+end

--- a/lib/checkout_sdk/oauth_scopes.rb
+++ b/lib/checkout_sdk/oauth_scopes.rb
@@ -47,5 +47,6 @@ module CheckoutSdk
     ISSUING_CARD_MGMT = 'issuing:card-mgmt'
     ISSUING_CONTROLS_READ = 'issuing:controls-read'
     ISSUING_CONTROLS_WRITE = 'issuing:controls-write'
+    FORWARD = 'forward'
   end
 end

--- a/spec/checkout_sdk/forward/forward_integration_spec.rb
+++ b/spec/checkout_sdk/forward/forward_integration_spec.rb
@@ -1,0 +1,59 @@
+RSpec.describe CheckoutSdk::Forward do
+
+  skip 'This test requires a valid id or Token source' do
+    describe '#forward_request' do
+      it 'sends a forward request and returns destination_response' do
+        request = {
+          source: {
+            id: 'src_v5rgkf3gdtpuzjqesyxmyodnya',
+            type: 'id'
+          },
+          reference: 'ORD-5023-4E89',
+          processing_channel_id: 'pc_azsiyswl7bwe2ynjzujy7lcjca',
+          network_token: {
+            enabled: true,
+            request_cryptogram: false
+          },
+          destination_request: {
+            url: 'https://example.com/payments',
+            method: 'POST',
+            headers: {
+              encrypted: '<JWE encrypted JSON object with string values>',
+              raw: {
+                'Idempotency-Key' => 'xe4fad12367dfgrds',
+                'Content-Type' => 'application/json'
+              }
+            },
+            body: '{"amount": 1000, "currency": "USD", "reference": "some_reference", "source": {"type": "card", "number": "{{card_number}}", "expiry_month": "{{card_expiry_month}}", "expiry_year": "{{card_expiry_year_yyyy}}", "name": "Ali Farid"}, "payment_type": "Regular", "authorization_type": "Final", "capture": true, "processing_channel_id": "pc_xxxxxxxxxxx", "risk": {"enabled": false}, "merchant_initiated": true}',
+            signature: {
+              type: 'dlocal',
+              dlocal_parameters: {
+                secret_key: '9f439fe1a9f96e67b047d3c1a28c33a2e'
+              }
+            }
+          }
+        }
+
+        response = client.forward_request(request)
+
+        expect(response).to include('request_id', 'destination_response')
+        expect(response['destination_response']).to include('status', 'body')
+      end
+    end
+
+    describe '#get' do
+      it 'retrieves a forward request by ID' do
+        forward_id = 'fwd_01HK153X00VZ1K15Z3HYC0QGPN'
+        response = client.get(forward_id)
+
+        expect(response).to include(
+                              'request_id',
+                              'reference',
+                              'destination_request',
+                              'destination_response'
+                            )
+        expect(response['destination_response']['status']).to eq(201)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull request introduces a new feature to the Checkout SDK: the `Forward` module, which facilitates forwarding requests to external destinations. The changes include adding the `ForwardClient` class, integrating it into the SDK's API, defining OAuth scopes for the feature, and adding integration tests. Below are the most important changes grouped by theme:

### Feature Implementation:
* Added a new `ForwardClient` class in `lib/checkout_sdk/forward/forward_client.rb`, which provides methods for sending forward requests (`forward_request`) and retrieving them by ID (`get`).
* Introduced the `Forward` module in `lib/checkout_sdk/forward/forward.rb`, which requires the `ForwardClient`.

### SDK Integration:
* Updated `lib/checkout_sdk.rb` to require the new `Forward` module.
* Modified the `CheckoutApi` class in `lib/checkout_sdk/checkout_api.rb` to include the `forward` attribute and initialize it with the `ForwardClient`. [[1]](diffhunk://#diff-c980179ff1330a51ee3d7b57e1b821d16925e5ec1029ffa96b0967cd2e4520f6R46-R47) [[2]](diffhunk://#diff-c980179ff1330a51ee3d7b57e1b821d16925e5ec1029ffa96b0967cd2e4520f6L67-R70) [[3]](diffhunk://#diff-c980179ff1330a51ee3d7b57e1b821d16925e5ec1029ffa96b0967cd2e4520f6R96)

### OAuth Scopes:
* Added a new OAuth scope `FORWARD` to the `OAuthScopes` module in `lib/checkout_sdk/oauth_scopes.rb`.

### Integration Tests:
* Added integration tests for the `Forward` module in `spec/checkout_sdk/forward/forward_integration_spec.rb`. These tests verify the functionality of `forward_request` and `get` methods.