### PR TITLE
Release 1.8.1 - Payment Request Product Type and Subtype to nullable

### DIFF
--- a/lib/checkout_sdk/version.rb
+++ b/lib/checkout_sdk/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CheckoutSdk
-  VERSION = '1.8.0'
+  VERSION = '1.8.1'
 end


### PR DESCRIPTION
This release adds support for product item types and subtypes in the payments module, improving the structure and clarity of product-related attributes. The main changes include introducing new enumerations for product item types and subtypes, updating documentation for better clarity, and requiring the new files where appropriate.

### Product Type Support Enhancements

* Added a new `ProductItemType` enumeration in `product_item_type.rb`, defining possible product types such as `digital`, `discount`, and `physical`.
* Updated the `product.rb` documentation to clarify the usage of the `type` and `sub_type` attributes, specifying their purpose and when they are required.
* Required the new `product_item_type` and `product_sub_type` files in `payments.rb` to ensure the enumerations are available throughout the payments module.