### PR TITLE
feature/INT-1656 - support for oauth scope vault apme-enrollment

### DIFF
--- a/lib/checkout_sdk/oauth_scopes.rb
+++ b/lib/checkout_sdk/oauth_scopes.rb
@@ -3,6 +3,7 @@
 module CheckoutSdk
   module OAuthScopes
     VAULT = 'vault'
+    VAULT_APME_ENROLLMENT = 'vault:apme-enrollment'
     VAULT_INSTRUMENTS = 'vault:instruments'
     VAULT_TOKENIZATION = 'vault:tokenization'
     GATEWAY = 'gateway'


### PR DESCRIPTION
This pull request introduces a new OAuth scope constant to the `CheckoutSdk::OAuthScopes` module. The change adds a specific scope for APME enrollment, which will help in authorizing and managing permissions more granularly.

New OAuth scope added:

* Added the `VAULT_APME_ENROLLMENT` constant with the value `'vault:apme-enrollment'` to the `OAuthScopes` module in `lib/checkout_sdk/oauth_scopes.rb`.