### PR TITLE
Release 1.11.0 - ChallengeIndicator/SessionChallengeIndicator enum alignment

### DIFF
--- a/lib/checkout_sdk/version.rb
+++ b/lib/checkout_sdk/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CheckoutSdk
-  VERSION = '1.10.0'
+  VERSION = '1.11.0'
 end


### PR DESCRIPTION
This release updates the Sessions API model to align with the latest Checkout.com API specification, adds missing fields, corrects value sets, and introduces comprehensive spec-conformance tests to prevent regressions. The changes improve the accuracy and maintainability of the SDK by ensuring all wire values and model fields match the API exactly, and by removing fields that are not part of the spec.

### API Model Corrections and Additions

* Added missing fields to `SessionRequest`, including `google_spa` (with new `GoogleSpa` model), `preferred_experiences` (with new `Experience` value module), and `device_information`. Removed the undocumented `prior_transaction_reference` field. [[1]](diffhunk://#diff-80f5c4e25d1c974a528fbc992adc5a40e4c3c6205ef51d17f99b62bf5b75c5e0R52-R57) [[2]](diffhunk://#diff-80f5c4e25d1c974a528fbc992adc5a40e4c3c6205ef51d17f99b62bf5b75c5e0L67) [[3]](diffhunk://#diff-80f5c4e25d1c974a528fbc992adc5a40e4c3c6205ef51d17f99b62bf5b75c5e0L77-R87) [[4]](diffhunk://#diff-c883f1978168d9882534f916b30fdb5653d061df41ba4112a2cc4e84b862a39cR1-R15) [[5]](diffhunk://#diff-11bf24feb8102ce9687e47826c5cc2890fb8e24d19285687330a6b3eec3ca1feR1-R18)
* Added the `SessionChallengeIndicator` value module to support the full set of challenge indicator values required by the Sessions API, and updated references from the shared payments challenge indicator. [[1]](diffhunk://#diff-0cafce128156dc297c867356d80d84c4d993f4d4bac4bcae1dcb521fd852414bR1-R31) [[2]](diffhunk://#diff-80f5c4e25d1c974a528fbc992adc5a40e4c3c6205ef51d17f99b62bf5b75c5e0L6-R6) [[3]](diffhunk://#diff-80f5c4e25d1c974a528fbc992adc5a40e4c3c6205ef51d17f99b62bf5b75c5e0L27-L35) [[4]](diffhunk://#diff-0c6ce976b5ecd9edfa6f053ab0efd8ee8ab669e577ee977d366689d317e28fb4R9-R15)
* Added missing fields to `BrowserSession` for Google SPA support: `iframe_payment_allowed` and `user_agent_client_hint`. [[1]](diffhunk://#diff-fd325e64d8743ed1e26f921b38e657c92f962c187cfcdf9aaf39592eb7c93bc7R29-R33) [[2]](diffhunk://#diff-fd325e64d8743ed1e26f921b38e657c92f962c187cfcdf9aaf39592eb7c93bc7L40-R47)
* Added new schemes to `SessionScheme`: `DISCOVER` and `UPI`.

### Value Corrections

* Corrected wire values to match the API spec: fixed `non_payment` to snake_case in `Category`, fixed `QUASI_CARD_TRANSACTION` spelling in `TransactionType`, updated `ThreeDsMethodCompletion` to use uppercase codes, and replaced `visa` with the correct set in `ShippingIndicator`. [[1]](diffhunk://#diff-60f682e7c6c6636c65d42c7e3dd98b8ad4a2c811021345bf986926d8c885e211L7-R7) [[2]](diffhunk://#diff-0510f9d68bf33ae35a2baf342937474593eb82f2510df41ce1cd1f855f4f4017L10-R10) [[3]](diffhunk://#diff-1a3d55b725819598fbfe2603949cff952f735307b03e10f6d868e6f51dc992adL6-R8) [[4]](diffhunk://#diff-2053ffc58ffbe246b9d8a5e0eb7feb32c11f0c40335bf2b0a5cd812a44d5a7e5R5-R18)

### Field Removals

* Removed the `store_for_future_use` field from `CardSource`, which is not present in the Sessions API model.

### Spec-Conformance Tests

* Added a comprehensive RSpec suite to verify that all value modules and model fields exactly match the Checkout.com API spec, catch casing errors, and prevent future regressions.

---

**References:**  
[[1]](diffhunk://#diff-80f5c4e25d1c974a528fbc992adc5a40e4c3c6205ef51d17f99b62bf5b75c5e0R52-R57) [[2]](diffhunk://#diff-80f5c4e25d1c974a528fbc992adc5a40e4c3c6205ef51d17f99b62bf5b75c5e0L67) [[3]](diffhunk://#diff-80f5c4e25d1c974a528fbc992adc5a40e4c3c6205ef51d17f99b62bf5b75c5e0L77-R87) [[4]](diffhunk://#diff-c883f1978168d9882534f916b30fdb5653d061df41ba4112a2cc4e84b862a39cR1-R15) [[5]](diffhunk://#diff-11bf24feb8102ce9687e47826c5cc2890fb8e24d19285687330a6b3eec3ca1feR1-R18) [[6]](diffhunk://#diff-0cafce128156dc297c867356d80d84c4d993f4d4bac4bcae1dcb521fd852414bR1-R31) [[7]](diffhunk://#diff-80f5c4e25d1c974a528fbc992adc5a40e4c3c6205ef51d17f99b62bf5b75c5e0L6-R6) [[8]](diffhunk://#diff-80f5c4e25d1c974a528fbc992adc5a40e4c3c6205ef51d17f99b62bf5b75c5e0L27-L35) [[9]](diffhunk://#diff-0c6ce976b5ecd9edfa6f053ab0efd8ee8ab669e577ee977d366689d317e28fb4R9-R15) [[10]](diffhunk://#diff-fd325e64d8743ed1e26f921b38e657c92f962c187cfcdf9aaf39592eb7c93bc7R29-R33) [[11]](diffhunk://#diff-fd325e64d8743ed1e26f921b38e657c92f962c187cfcdf9aaf39592eb7c93bc7L40-R47) [[12]](diffhunk://#diff-623cbf747db9e5eed75693d775dcc4904ba1d931e7103ae4b8cd444d80be9cd6R12-R13) [[13]](diffhunk://#diff-60f682e7c6c6636c65d42c7e3dd98b8ad4a2c811021345bf986926d8c885e211L7-R7) [[14]](diffhunk://#diff-0510f9d68bf33ae35a2baf342937474593eb82f2510df41ce1cd1f855f4f4017L10-R10) [[15]](diffhunk://#diff-1a3d55b725819598fbfe2603949cff952f735307b03e10f6d868e6f51dc992adL6-R8) [[16]](diffhunk://#diff-2053ffc58ffbe246b9d8a5e0eb7feb32c11f0c40335bf2b0a5cd812a44d5a7e5R5-R18) [[17]](diffhunk://#diff-20b6e424a4938704fcf0f81c784047ddf188f0828d35408284e671cd2aee61f2L15-R20) [[18]](diffhunk://#diff-c2ac5aadc63871c3a539981b7e5aa98cfee8428e2d696823f5f58a45fc4d0d9bR1-R200)