### PR TITLE
feat(payments): add scheme_transaction_link_id to ProcessingData

### DIFF
--- a/lib/checkout_sdk/payments/processing_data.rb
+++ b/lib/checkout_sdk/payments/processing_data.rb
@@ -5,12 +5,94 @@ module CheckoutSdk
     # Response-side `processing` object returned alongside payment responses.
     # Distinct from {ProcessingSettings} which is the request-side equivalent.
     #
-    # Mirrors the swagger ProcessingData schema:
-    #   preferred_scheme, app_id, partner_*, tax_amount, locale, retrieval_reference_number,
-    #   cko_network_token_available (SDK-only), aft, merchant_category_code, scheme_merchant_id,
-    #   pan_type_processed, fallback_source_used, failure_code, partner_code, partner_response_code,
-    #   scheme, partner_fraud_status, partner_merchant_advice_code, accommodation_data, airline_data,
-    #   custom_payment_method_ids
+    # Mirrors the swagger ProcessingData schema, referenced by PaymentDetails.processing
+    # (GET /payments/{id}).
+    #
+    # @!attribute preferred_scheme
+    #   @return [String] [Optional] The preferred scheme for co-badged card payment processing.
+    #     If performing 3DS via a third party, this is the scheme that processed 3DS. Does not
+    #     support PINless debit schemes in the US (STAR, PULSE, NYCE, ACCEL, SHAZAM).
+    #     Enum: "mastercard" "visa" "cartes_bancaires"
+    # @!attribute app_id
+    #   @return [String] [Optional] The customer's application identifier.
+    # @!attribute partner_customer_id
+    #   @return [String] [Optional] The customer's ID on the partner platform.
+    # @!attribute partner_payment_id
+    #   @return [String] [Optional] The partner-originated unique payment identifier.
+    # @!attribute tax_amount
+    #   @return [Numeric] [Optional] Total tax amount of the order.
+    # @!attribute locale
+    #   @return [String] [Optional] The language and region of the customer. ISO 639-2 language
+    #     code, its value consists of language-country. Pattern:
+    #     ^[a-z]{2}(?:-[A-Z][a-z]{3})?(?:-(?:[A-Z]{2}))?$ - min 2 characters, max 10 characters
+    # @!attribute retrieval_reference_number
+    #   @return [String] [Optional] A unique identifier for the authorization provided by partner.
+    # @!attribute partner_order_id
+    #   @return [String] [Optional] The Klarna order ID associated with the payment.
+    # @!attribute partner_status
+    #   @return [String] [Optional] Status of a payment provided by partner.
+    # @!attribute partner_transaction_id
+    #   @return [String] [Optional] Unique transaction identification provided by partner.
+    # @!attribute partner_error_codes
+    #   @return [Array<String>] [Optional] The list of error codes that led the payment to fail or
+    #     be declined, as given by the payment provider.
+    # @!attribute partner_error_message
+    #   @return [String] [Optional] Error description provided by partner.
+    # @!attribute partner_authorization_code
+    #   @return [String] [Optional] Authorization code provided by partner.
+    # @!attribute partner_authorization_response_code
+    #   @return [String] [Optional] Authorization response code provided by partner.
+    # @!attribute partner_fraud_status
+    #   @return [String] [Optional] Partner fraud status. If the status is Pending, and the
+    #     merchant captures before it changes to Accepted, the risk of the transaction is solely
+    #     on the merchant.
+    # @!attribute partner_merchant_advice_code
+    #   @return [String] [Optional] The Mastercard Merchant Advice Code (MAC), which contains
+    #     additional information about the transaction. For declined transactions it also
+    #     indicates whether the payment can be retried and how long to wait.
+    # @!attribute custom_payment_method_ids
+    #   @return [Array<String>] [Optional] An array defining which of the configured payment
+    #     options within a payment category (for example, pay_later or pay_over_time) should be
+    #     displayed for this purchase.
+    # @!attribute aft
+    #   @return [Boolean] [Optional] Indicates whether the payment is an Account Funding
+    #     Transaction.
+    # @!attribute merchant_category_code
+    #   @return [String] [Optional] Four-digit code for retail financial services expressed in
+    #     ISO 18245 format, classifying the types of goods or services you provide.
+    # @!attribute scheme_merchant_id
+    #   @return [String] [Optional] The merchant identifier that was configured with the scheme
+    #     and used for the payment.
+    # @!attribute pan_type_processed
+    #   @return [String] [Optional] The type of Primary Account Number (PAN) used for the payment.
+    #     DPAN indicates a network token was used, FPAN indicates the full card was used.
+    #     Enum: "fpan" "dpan"
+    # @!attribute fallback_source_used
+    #   @return [Boolean] [Optional] Indicates whether the fallback_source field was used for
+    #     the payment.
+    # @!attribute failure_code
+    #   @return [String] [Optional] A high-level failure category returned by the payment provider
+    #     when a payment is declined or fails. Not all payment methods return this field.
+    # @!attribute partner_code
+    #   @return [String] [Optional] The 6-digit partner code returned by the payment provider.
+    #     Returned when source.type is blik. Pattern: ^\d{6}$ - 6 characters
+    # @!attribute partner_response_code
+    #   @return [String] [Optional] The raw response code returned by the payment provider when a
+    #     payment is declined or fails. Not all payment methods return this field.
+    # @!attribute scheme
+    #   @return [String] [Optional] The scheme on which the payment was authorized. This may
+    #     differ from the card's scheme used for the payment if the card is co-badged and the
+    #     payment was authorized on a different network. Read-only.
+    # @!attribute accommodation_data
+    #   @return [Array<AccommodationData>] [Optional] Contains information about the accommodation
+    #     booked by the customer.
+    # @!attribute airline_data
+    #   @return [Array<AirlineData>] [Optional] Contains information about the airline ticket and
+    #     flights booked by the customer.
+    # @!attribute scheme_transaction_link_id
+    #   @return [String] [Optional] The scheme transaction link identifier. Returned for
+    #     Mastercard transactions when the scheme provides a link identifier that ties together
+    #     related transactions on the network.
     class ProcessingData
       attr_accessor :preferred_scheme,
                     :app_id,
@@ -39,7 +121,8 @@ module CheckoutSdk
                     :partner_response_code,
                     :scheme,
                     :accommodation_data,
-                    :airline_data
+                    :airline_data,
+                    :scheme_transaction_link_id
     end
   end
 end

--- a/spec/checkout_sdk/payments/processing_data_spec.rb
+++ b/spec/checkout_sdk/payments/processing_data_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+# Response-side `processing` object (swagger ProcessingData, GET /payments/{id}).
+# Verifies every attribute of the schema is exposed and round-trips through the accessors.
+PROCESSING_DATA_ATTRIBUTES = {
+  preferred_scheme: 'cartes_bancaires',
+  app_id: 'com.iap.linker_portal',
+  partner_customer_id: '2102209000001106125F8',
+  partner_payment_id: '440644309099499894406',
+  tax_amount: 1000,
+  locale: 'en-US',
+  retrieval_reference_number: '909913440644',
+  partner_order_id: 'ord_abc',
+  partner_status: 'pending',
+  partner_transaction_id: 'txn_abc',
+  partner_error_codes: %w[ERR_001 ERR_002],
+  partner_error_message: 'Payment declined',
+  partner_authorization_code: 'auth_123',
+  partner_authorization_response_code: '00',
+  partner_fraud_status: 'Pending',
+  partner_merchant_advice_code: '24',
+  custom_payment_method_ids: %w[cpm_001],
+  aft: true,
+  merchant_category_code: '5311',
+  scheme_merchant_id: '123456',
+  pan_type_processed: 'fpan',
+  fallback_source_used: false,
+  failure_code: 'partner_error',
+  partner_code: '999111',
+  partner_response_code: 'ER_WRONG_TICKET',
+  scheme: 'ACCEL',
+  scheme_transaction_link_id: 'MTL-XYZ-789'
+}.freeze
+
+RSpec.describe CheckoutSdk::Payments::ProcessingData do
+  PROCESSING_DATA_ATTRIBUTES.each do |attribute, value|
+    it "exposes #{attribute}" do
+      data = described_class.new
+      data.public_send("#{attribute}=", value)
+
+      expect(data.public_send(attribute)).to eq(value)
+    end
+  end
+
+  it 'exposes accommodation_data and airline_data as collections' do
+    data = described_class.new
+    data.accommodation_data = [{ name: 'Grand Hotel' }]
+    data.airline_data = [{ ticket: { number: '045-21351455613' } }]
+
+    expect(data.accommodation_data.first[:name]).to eq('Grand Hotel')
+    expect(data.airline_data.first[:ticket][:number]).to eq('045-21351455613')
+  end
+
+  it 'leaves every attribute nil when nothing is set' do
+    data = described_class.new
+
+    expect(PROCESSING_DATA_ATTRIBUTES.keys.map { |a| data.public_send(a) }).to all(be_nil)
+  end
+end


### PR DESCRIPTION
**Summary**

Adds `processing.scheme_transaction_link_id` (the Mastercard Transaction Link Identifier) to the response-side `ProcessingData` model. The field was already exposed on the request side (`ProcessingSettings`) but not on the response, so merchants could send it and never read it back (INT-1686, Mastercard mandate deadline 2026-10-23).

With this the Ruby model covers the swagger `ProcessingData` schema in full.

**Changes**
- `lib/checkout_sdk/payments/processing_data.rb` — added the `scheme_transaction_link_id` accessor; replaced the summary comment with per-attribute YARD documentation for all 29 attributes, carrying the swagger descriptions and constraints (`locale` pattern and length, `partner_code` pattern, `preferred_scheme` and `pan_type_processed` enum values)
- `spec/checkout_sdk/payments/processing_data_spec.rb` — new spec: covers every attribute of the schema, the accommodation and airline collections, and the all-nil default state

**API Reference**
- `GET /payments/{id}` — `PaymentDetails.processing` (`ProcessingData` schema)

**Breaking changes**

None. One new optional response attribute plus documentation.

**README**

No impact. The README does not document individual response fields.