### PR TITLE
feat(payments): add optional amount to VoidRequest for partial voids

### DIFF
--- a/lib/checkout_sdk/payments/void_request.rb
+++ b/lib/checkout_sdk/payments/void_request.rb
@@ -2,12 +2,16 @@
 
 module CheckoutSdk
   module Payments
+    # @!attribute amount
+    #   @return [Integer] the amount to void, min 0, max 9999999999.
+    #     If not specified, the full payment amount is voided.
     # @!attribute reference
     #   @return [String]
     # @!attribute metadata
     #   @return [Hash{String => Object}]
     class VoidRequest
-      attr_accessor :reference,
+      attr_accessor :amount,
+                    :reference,
                     :metadata
     end
   end

--- a/spec/checkout_sdk/payments/void_request_serialization_spec.rb
+++ b/spec/checkout_sdk/payments/void_request_serialization_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+RSpec.describe CheckoutSdk::Payments::VoidRequest do
+  it 'serializes amount when set' do
+    request = described_class.new
+    request.amount = 500
+    request.reference = 'partial-void'
+
+    hash = CheckoutSdk::JsonSerializer.to_custom_hash(request)
+
+    expect(hash['amount']).to eq(500)
+    expect(hash['reference']).to eq('partial-void')
+  end
+
+  it 'omits amount from the serialized body when not set' do
+    request = described_class.new
+    request.reference = 'full-void'
+
+    hash = CheckoutSdk::JsonSerializer.to_custom_hash(request)
+
+    expect(hash).not_to have_key('amount')
+    expect(hash.to_json).not_to include('amount')
+    expect(hash['reference']).to eq('full-void')
+  end
+end


### PR DESCRIPTION
**Summary**
Adds the optional `amount` field to the payment void request, introduced in the API spec on 2026-08-13. When set, only that amount is voided; when omitted, the full payment amount is voided, exactly as before.

**Changes**
- Void request model: new optional `amount` (integer, min 0, max 9999999999) with doc comment
- Serialization tests: amount present when set, and absent from the body when unset, so existing full-void callers keep sending an identical payload

**API Reference**
- `POST /payments/{id}/voids` (`VoidRequest.amount`)

**Breaking changes**
None.

**README**
No README impact.