### PR TITLE
feat(accounts): add ISV payout schedule fields and payment_instrument_id

### DIFF
--- a/lib/checkout_sdk/accounts/schedule_frequency_daily.rb
+++ b/lib/checkout_sdk/accounts/schedule_frequency_daily.rb
@@ -2,6 +2,8 @@
 
 module CheckoutSdk
   module Accounts
+    # For SaaS sellers (ISV), a daily schedule runs on working days only (Monday to Friday);
+    # payouts do not take place on weekends.
     class ScheduleFrequencyDaily < ScheduleRequest
       def initialize
         super(ScheduleFrequencyType::DAILY)

--- a/lib/checkout_sdk/accounts/schedule_frequency_monthly.rb
+++ b/lib/checkout_sdk/accounts/schedule_frequency_monthly.rb
@@ -3,7 +3,9 @@
 module CheckoutSdk
   module Accounts
     # @!attribute by_month_day
-    #   @return [Array(Integer)]
+    #   @return [Array(Integer)] The day or days of the month the payout should take place.
+    #     For SaaS sellers (ISV), only the following combinations are supported, in any order:
+    #     [1], [15], [1, 15] or [1, 16].
     class ScheduleFrequencyMonthly < ScheduleRequest
       attr_accessor :by_month_day
 

--- a/lib/checkout_sdk/accounts/schedule_frequency_weekly.rb
+++ b/lib/checkout_sdk/accounts/schedule_frequency_weekly.rb
@@ -3,7 +3,9 @@
 module CheckoutSdk
   module Accounts
     # @!attribute by_day
-    #   @return [Array(String)]
+    #   @return [Array(String)] The day or days of the week the payout should take place.
+    #     For SaaS sellers (ISV), only working days (Monday to Friday) are supported;
+    #     payouts set to take place on weekends are rejected.
     class ScheduleFrequencyWeekly < ScheduleRequest
       attr_accessor :by_day
 

--- a/lib/checkout_sdk/accounts/update_schedule.rb
+++ b/lib/checkout_sdk/accounts/update_schedule.rb
@@ -6,11 +6,22 @@ module CheckoutSdk
     #   @return [TrueClass, FalseClass]
     # @!attribute threshold
     #   @return [TrueClass, FalseClass]
+    # @!attribute balance_minimum
+    #   @return [Integer] The amount, in the minor units of the schedule's currency, to retain in the
+    #     sub-entity's available balance. SaaS sellers (ISV) only. Defaults to 0 if you do not set it.
+    # @!attribute carry_forward_enabled
+    #   @return [TrueClass, FalseClass] Indicates whether to carry forward any balance below the configured
+    #     minimum to the next payout. SaaS sellers (ISV) only. Defaults to false if you do not set it.
+    # @!attribute payment_instrument_id
+    #   @return [String] The ID of the platforms payment instrument used as the payout destination.
     # @!attribute recurrence
     #   @return [ScheduleRequest]
     class UpdateSchedule
       attr_accessor :enabled,
                     :threshold,
+                    :balance_minimum,
+                    :carry_forward_enabled,
+                    :payment_instrument_id,
                     :recurrence
     end
   end

--- a/spec/checkout_sdk/accounts/schedule_frequency_casing_spec.rb
+++ b/spec/checkout_sdk/accounts/schedule_frequency_casing_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+RSpec.describe CheckoutSdk::Accounts::ScheduleFrequencyType do
+  # Characterization: the OpenAPI spec declares the payout schedule frequency
+  # enum lowercase (weekly, daily, monthly), but this SDK has sent capitalized
+  # values since the Accounts module was introduced (deef7f1), and Java shares
+  # the capitalized casing while .NET, Go, PHP and Python send lowercase. Until
+  # the platform confirms which casing the API canonically accepts (likely a
+  # spec bug, or the API accepts both), these examples pin what the SDK sends
+  # today so any change is a deliberate decision, not an accident.
+  it 'serializes the capitalized frequency values the SDK has always sent' do
+    expect(described_class::WEEKLY).to eq('Weekly')
+    expect(described_class::DAILY).to eq('Daily')
+    expect(described_class::MONTHLY).to eq('Monthly')
+  end
+
+  it 'sends the capitalized frequency in the update schedule body' do
+    schedule = CheckoutSdk::Accounts::ScheduleFrequencyWeekly.new
+    schedule.by_day = %w[monday]
+
+    hash = CheckoutSdk::JsonSerializer.to_custom_hash(schedule)
+
+    expect(hash['frequency']).to eq('Weekly')
+  end
+end

--- a/spec/checkout_sdk/accounts/update_schedule_serialization_spec.rb
+++ b/spec/checkout_sdk/accounts/update_schedule_serialization_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Payout schedule (UpdateSchedule) serialization' do
+  def serialize(object)
+    CheckoutSdk::JsonSerializer.to_custom_hash(object)
+  end
+
+  it 'serializes ISV fields and payment_instrument_id when set' do
+    recurrence = CheckoutSdk::Accounts::ScheduleFrequencyWeekly.new
+    recurrence.by_day = %w[monday friday]
+
+    schedule = CheckoutSdk::Accounts::UpdateSchedule.new
+    schedule.enabled = true
+    schedule.threshold = 100
+    schedule.balance_minimum = 500
+    schedule.carry_forward_enabled = true
+    schedule.payment_instrument_id = 'ppi_w4jelhppmfiufdnatam37wrfc4'
+    schedule.recurrence = recurrence
+
+    hash = serialize(schedule)
+
+    expect(hash['enabled']).to eq(true)
+    expect(hash['threshold']).to eq(100)
+    expect(hash['balance_minimum']).to eq(500)
+    expect(hash['carry_forward_enabled']).to eq(true)
+    expect(hash['payment_instrument_id']).to eq('ppi_w4jelhppmfiufdnatam37wrfc4')
+    expect(hash['recurrence']['frequency']).to eq(CheckoutSdk::Accounts::ScheduleFrequencyType::WEEKLY)
+    expect(hash['recurrence']['by_day']).to eq(%w[monday friday])
+  end
+
+  it 'omits ISV fields and payment_instrument_id when unset' do
+    recurrence = CheckoutSdk::Accounts::ScheduleFrequencyDaily.new
+
+    schedule = CheckoutSdk::Accounts::UpdateSchedule.new
+    schedule.enabled = true
+    schedule.recurrence = recurrence
+
+    hash = serialize(schedule)
+
+    expect(hash['enabled']).to eq(true)
+    expect(hash['recurrence']['frequency']).to eq(CheckoutSdk::Accounts::ScheduleFrequencyType::DAILY)
+    expect(hash).not_to have_key('balance_minimum')
+    expect(hash).not_to have_key('carry_forward_enabled')
+    expect(hash).not_to have_key('payment_instrument_id')
+    expect(hash).not_to have_key('threshold')
+  end
+
+  it 'serializes monthly recurrence with by_month_day' do
+    recurrence = CheckoutSdk::Accounts::ScheduleFrequencyMonthly.new
+    recurrence.by_month_day = [1, 15]
+
+    schedule = CheckoutSdk::Accounts::UpdateSchedule.new
+    schedule.enabled = true
+    schedule.recurrence = recurrence
+
+    hash = serialize(schedule)
+
+    expect(hash['recurrence']['frequency']).to eq(CheckoutSdk::Accounts::ScheduleFrequencyType::MONTHLY)
+    expect(hash['recurrence']['by_month_day']).to eq([1, 15])
+  end
+end


### PR DESCRIPTION
**Summary**
Adds the 2026-08-05 spec changes: the ISV (SaaS seller) payout schedule fields `balance_minimum` and `carry_forward_enabled`, plus `payment_instrument_id` which was present in the spec but missing from the SDK. Includes characterization tests pinning the payout schedule GET response shape and frequency serialization the API actually uses.

**Changes**
- Payout schedule request/response models: new optional `balance_minimum`, `carry_forward_enabled`, `payment_instrument_id`
- ISV constraints documented on the existing frequency types (working days only for weekly and daily; monthly accepts only [1], [15], [1,15] or [1,16]); no parallel Isv classes because the wire format is identical
- Serialization tests: fields present when set, absent when unset; spec-shape characterization tests

**API Reference**
- `GET /accounts/entities/{id}/payout-schedules`
- `PUT /accounts/entities/{id}/payout-schedules`

**Breaking changes**
None.

**README**
No README impact.