### PR TITLE
Release 2.0.0

### DIFF
--- a/lib/checkout_sdk/version.rb
+++ b/lib/checkout_sdk/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CheckoutSdk
-  VERSION = '1.12.0'
+  VERSION = '2.0.0'
 end


### PR DESCRIPTION
- The merchant-specific subdomain (with_environment_subdomain) is now required. Set it, or call the deprecated with_legacy_domain to keep using the shared checkout.com hosts (#193)
- An invalid subdomain now raises instead of being silently ignored (#193)
- Add optional amount to VoidRequest to support partial voids (#196)
- Add the ISV (SaaS seller) payout schedule fields balance_minimum, carry_forward_enabled and payment_instrument_id (#197)