### PR TITLE
Release 2.1.0 - BACS Direct Debit notifications + refactor

### DIFF
--- a/lib/checkout_sdk/version.rb
+++ b/lib/checkout_sdk/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CheckoutSdk
-  VERSION = '2.0.0'
+  VERSION = '2.1.0'
 end


### PR DESCRIPTION
### Breaking changes (check at the end <img width="22" height="22" alt="image" src="https://github.com/user-attachments/assets/aff83459-ab22-4048-b196-8023ea41dc58" />)

This release introduces support for Bacs Direct Debit and ACH payment instruments, as well as improvements and clarifications to the SDK's type documentation. The main changes include adding Bacs and ACH instrument models, enabling Bacs notifications, and updating type definitions to support new use cases and improve clarity.

**Bacs Direct Debit support:**

* Added Bacs Direct Debit client (`BacsClient`) with support for sending pre-notification requests (`send_notification`) and corresponding request/response types. (`lib/checkout_sdk/apm/apm.rb`, `lib/checkout_sdk/apm/bacs/bacs_client.rb`, `lib/checkout_sdk/apm/bacs/bacs_notification_request.rb`, `lib/checkout_sdk/apm/bacs/bacs_notification_type.rb`) [[1]](diffhunk://#diff-5afccd1ac5a4ff11c62c5927f5c081692d7f3e57e84186cbabf75292e092e397R12-R16) [[2]](diffhunk://#diff-9d96f657f9ef049a441ffda6c033620c9b47754700b9fac3aa8ca8beb26854a8R1-R29) [[3]](diffhunk://#diff-4423dd2a291ed710ec6cc8418b7f210d9ea505caceebfc16b8f3cccb9afd6ae9R1-R52) [[4]](diffhunk://#diff-45f49922a32c19e9f592c83d0e4220de8e05dfd842787986bb5b21a9fe3263b8R1-R10)
* Registered the Bacs client in `CheckoutApi`, making it available as `api.bacs`. (`lib/checkout_sdk/checkout_api.rb`) [[1]](diffhunk://#diff-c980179ff1330a51ee3d7b57e1b821d16925e5ec1029ffa96b0967cd2e4520f6R76-R77) [[2]](diffhunk://#diff-c980179ff1330a51ee3d7b57e1b821d16925e5ec1029ffa96b0967cd2e4520f6R96) [[3]](diffhunk://#diff-c980179ff1330a51ee3d7b57e1b821d16925e5ec1029ffa96b0967cd2e4520f6R137)
* Added models for creating Bacs instruments, including account details, billing address, account holder, and payment type. (`lib/checkout_sdk/instruments/create/create_bacs_instrument_data.rb`, `lib/checkout_sdk/instruments/create/create_bacs_billing_address.rb`, `lib/checkout_sdk/instruments/create/create_bacs_account_holder.rb`, `lib/checkout_sdk/instruments/create/create_bacs_instrument_account.rb`, `lib/checkout_sdk/instruments/bacs_payment_type.rb`) [[1]](diffhunk://#diff-f94fb55dc8564fcfb444b677d5149248b0d1ead6c322d815ca814036ef2db5e0R1-R36) [[2]](diffhunk://#diff-47777b5969fa7fdb2e9c9db8a39f4a752c5c91f569189cff3a19464ac28406d4R1-R30) [[3]](diffhunk://#diff-069edacfc3c94c456181dfb9d4f6a677496701f479aa771eaf8d44e37f22e031R1-R24) [[4]](diffhunk://#diff-d8b7c08c7a5a15b1f13db9dc4e671bc91a7b9b3badba286fa47df09a401d1ae3R1-R14) [[5]](diffhunk://#diff-e09308ae90b88b674f4d081bca2c78e6e7c576537615f0a8e4719d3f1ada6094R1-R15)
* Added `BACS` as a supported payment source and instrument type. (`lib/checkout_sdk/common/payment_source_type.rb`, `lib/checkout_sdk/common/instrument_type.rb`) [[1]](diffhunk://#diff-a187b6a322344dbd86eeeb330d74194afde5299168e0c7e5af268da7744eb472R57) [[2]](diffhunk://#diff-56212207bb1829b18f15c1a066f99636a368f5969123d99adac314a70514e960R5-R14)

**ACH Direct Debit support:**

* Added models for creating ACH instruments, including account holder details, instrument data, and account type. (`lib/checkout_sdk/instruments/create/create_ach_account_holder.rb`, `lib/checkout_sdk/instruments/create/create_ach_instrument_data.rb`, `lib/checkout_sdk/instruments/ach_account_type.rb`) [[1]](diffhunk://#diff-191341f46a3fd4f8ce1875b318db3aefb06b88b674b65c11c1194ed0dd122efaR1-R29) [[2]](diffhunk://#diff-353f0e2867cca0a791161daafa855cfb98c29f626142c8bcf220f6a802c6ceb6R1-R30) [[3]](diffhunk://#diff-807ff476a7710442176f0bf1fd81f2bbf910fbb4b5dfe819d5f1b7f07bb7d536R1-R14)
* Added `ACH` as a supported instrument and payment source type. (`lib/checkout_sdk/common/instrument_type.rb`, `lib/checkout_sdk/common/payment_source_type.rb`) [[1]](diffhunk://#diff-56212207bb1829b18f15c1a066f99636a368f5969123d99adac314a70514e960R5-R14) [[2]](diffhunk://#diff-a187b6a322344dbd86eeeb330d74194afde5299168e0c7e5af268da7744eb472R57)

**SEPA Direct Debit improvements:**

* Added models for creating SEPA instruments, including account holder and billing address. (`lib/checkout_sdk/instruments/create/create_sepa_account_holder.rb`, `lib/checkout_sdk/instruments/create/create_sepa_billing_address.rb`) [[1]](diffhunk://#diff-635ee792e7d5f9917a1a8781a13a682d899d1a054ded7d01c16e6b385f2d0945R1-R28) [[2]](diffhunk://#diff-6f1150bc4168818299ab91c2ec9f83b742207a0df52739d25066d708b7963d63R1-R31)

**Type and documentation enhancements:**

* Improved documentation for `AccountHolderType`, `CustomerRequest`, and `InstrumentType`, clarifying usage and adding new values such as `GOVERNMENT` and `BACS`. (`lib/checkout_sdk/common/account_holder_type.rb`, `lib/checkout_sdk/common/customer_request.rb`, `lib/checkout_sdk/common/instrument_type.rb`) [[1]](diffhunk://#diff-2dd2ec9ff8e694af2b27eecdcf2fc903128d2f93a8fcfb5f3fa7df8b28b2abc0R5-R17) [[2]](diffhunk://#diff-d3e662e5e64b6cd8e71d57514afba9bf5b8a23d76971dcbcbc5991e64fabfa04R5-R28) [[3]](diffhunk://#diff-56212207bb1829b18f15c1a066f99636a368f5969123d99adac314a70514e960R5-R14)

These changes add significant new functionality for direct debit payments and improve the SDK's clarity and extensibility.


### Breaking changes <img width="22" height="22" alt="image" src="https://github.com/user-attachments/assets/aff83459-ab22-4048-b196-8023ea41dc58" /><img width="22" height="22" alt="image" src="https://github.com/user-attachments/assets/aff83459-ab22-4048-b196-8023ea41dc58" /><img width="22" height="22" alt="image" src="https://github.com/user-attachments/assets/aff83459-ab22-4048-b196-8023ea41dc58" />

Two, plus a set of behaviour changes that make previously-invalid requests valid. Everything else in this PR is additive.

### 1. `CheckoutSdk::Instruments::InstrumentData` has been removed

It was a single class serving the SEPA instrument's `instrument_data`, and it carried two defects:

- Its `payment_type` YARD pointed at `CheckoutSdk::Payments::PaymentType` — the **payment-level** enum (`Regular`, `Recurring`, `Moto`, `Installment`, `Unscheduled`). SEPA instruments declare `payment_type` as lowercase `recurring` / `regular`, so following the documentation produced a request the API rejects. The repo's own integration spec did exactly that.
- Its `date_of_signature` was documented as `DateTime`. The field is `format: date` and the API expects `yyyy-MM-dd`, so a `DateTime` serialized to a full timestamp.

It is replaced by per-scheme, spec-literal classes. The store and update shapes are genuinely different in the specification — different required sets and different `maxLength` values on the same fields — so they are separate types rather than one shared one.

**Migration**

```ruby
# before
data = CheckoutSdk::Instruments::InstrumentData.new
data.account_number = 'FR7630006000011234567890189'
data.country = CheckoutSdk::Common::Country::FR
data.currency = CheckoutSdk::Common::Currency::EUR
data.payment_type = CheckoutSdk::Payments::PaymentType::RECURRING   # 'Recurring' - wrong for SEPA
data.date_of_signature = DateTime.now                               # wrong format

request = CheckoutSdk::Instruments::InstrumentSepa.new
request.instrument_data = data
request.account_holder = account_holder                             # Common::AccountHolder

# after
data = CheckoutSdk::Instruments::CreateSepaInstrumentData.new
data.account_number = 'FR7630006000011234567890189'
data.country = CheckoutSdk::Common::Country::FR
data.currency = CheckoutSdk::Common::Currency::EUR
data.payment_type = CheckoutSdk::Instruments::SepaPaymentType::RECURRING   # 'recurring'
data.type = CheckoutSdk::Instruments::SepaMandateType::CORE                # optional
data.date_of_signature = '2026-07-15'                                      # yyyy-MM-dd String

billing_address = CheckoutSdk::Instruments::CreateSepaBillingAddress.new
billing_address.address_line1 = 'Cloverfield St.'
billing_address.address_line2 = '23A'
billing_address.city = 'London'
billing_address.zip = 'SW1A 1AA'
billing_address.country = CheckoutSdk::Common::Country::GB

account_holder = CheckoutSdk::Instruments::CreateSepaAccountHolder.new
account_holder.first_name = 'John'
account_holder.last_name = 'Smith'
account_holder.billing_address = billing_address

request = CheckoutSdk::Instruments::InstrumentSepa.new
request.instrument_data = data
request.account_holder = account_holder
```

`InstrumentSepa` itself is unchanged apart from gaining the `customer` attribute the specification declares. Because the SDK is duck-typed, a `Hash` also works if you prefer not to adopt the new classes.

### 2. `CheckoutSdk::Instruments::PaymentNetwork` values changed casing

Four of six values were wrong on the wire. The constant names are unchanged, so nothing fails to load — but **the string sent to the API is different**:

| constant | before | after |
|---|---|---|
| `PaymentNetwork::FPS` | `'Fps'` | `'fps'` |
| `PaymentNetwork::ACH` | `'Ach'` | `'ach'` |
| `PaymentNetwork::FEDWIRE` | `'Fedwire'` | `'fedwire'` |
| `PaymentNetwork::SWIFT` | `'Swift'` | `'swift'` |

`LOCAL` and `SEPA` were already correct. These are query-parameter values on `GET /validation/bank-accounts/{country}/{currency}`; the specification declares all six lowercase, so the four capitalized ones were **silently ignored as a filter** rather than rejected. If you were passing them and relying on the unfiltered result, the response will now be narrower — which is the documented behaviour. If you hardcoded the lowercase strings yourself, nothing changes for you.

### Behaviour changes that fix previously-invalid requests

Neither is a compile or load break in Ruby, but both change what a correct integration should send.

- **`Payments::AchSource#account_type`** now documents `Payments::AchSourceAccountType` (`savings` / `checking` / `cash`). It previously pointed at `Common::AccountType`, which is `savings` / **`current`** / `cash`. `PaymentRequestAchSource` is the only schema in the specification declaring `checking`, and it does not accept `current` — so `Common::AccountType::CURRENT` never produced a valid ACH payment source, and `checking` could not be named at all. `Common::AccountType` is unchanged and remains correct for the seven bank-account positions that do declare `current`.
- **`date_of_signature`** on both SEPA instrument-data classes is a `yyyy-MM-dd` String, not a `DateTime`. See above.

### What's new (additive)

**`cko.bacs.send_notification(request)`** — `POST /apms/bacs/notifications`, secret key. Sends a Bacs Direct Debit pre-notification. Registered on the current-API `CheckoutApi` only; the previous platform does not expose it.

```ruby
request = CheckoutSdk::Apm::BacsNotificationRequest.new
request.source_id = 'src_wmlfc3zyhqzehihu7giusaaawu'
request.notification_type = CheckoutSdk::Apm::BacsNotificationType::ADVANCE_NOTICE
request.collection_date = '2026-07-15'
request.amount = 4999
request.currency = CheckoutSdk::Common::Currency::GBP
request.billing_descriptor = 'CHECKOUT'
request.customer_email = 'customer@example.com'
request.support_email = 'support@test.com'
# optional: reference, support_phone

response = cko.bacs.send_notification(request)
response.event_id
```

**Bacs, SEPA and ACH instruments** — `InstrumentBacs`, `InstrumentAch`, `UpdateInstrumentBacs`, `UpdateInstrumentSepa`, `UpdateInstrumentAch`, plus 15 value classes and 5 enums (`SepaPaymentType`, `BacsPaymentType`, `SepaMandateType`, `AchAccountType`, `InstrumentAccountHolderType`).

**Payment sources** — `BacsSource`, plus the 12 APM variants that had no dedicated class: `AlipayCnSource`, `AlipayHkSource`, `DanaSource`, `GcashSource`, `KakaopaySource`, `MobilePaySource`, `PayNowSource`, `SwishSource` (with `SwishAccountHolder` and `SwishBillingDescriptor`), `TngSource`, `TruemoneySource`, `TwintSource`, `VippsSource`. Ruby now covers all 39 request-source variants the specification declares.

> Seven of those wire types were already reachable through `AlipayPlusSource` factory methods (`alipay_plus_cn_source` and friends). Those factories are **retained** and still work; a test asserts they produce byte-identical JSON to the new dedicated classes. Prefer the dedicated class going forward.

**`SepaSource#mandate_type`** — the `Core` / `B2B` mandate type the SEPA payment source declares and the SDK could not send.

**Enum additions** — `Common::InstrumentType`: `ACH`, `BACS`. `Common::PaymentSourceType`: `BACS`, `MOBILEPAY`, `PAYNOW`, `SWISH`, `TWINT`, `VIPPS`. `Common::AccountHolderType`: `GOVERNMENT`.

### Two casing traps documented in the code

Both are real specification behaviour, not SDK quirks, and both now carry regression tests so they cannot be "tidied up" later:

- **Bacs `payment_type` is capitalized (`Recurring` / `Regular`); SEPA `payment_type` is lowercase (`recurring` / `regular`).** Two separate enums; the values are not interchangeable.
- **`account_holder.type` on the SEPA *payment source*:** the specification declares `Individual` / `Corporate` capitalized at that one position, against 23 lowercase account-holder-type positions elsewhere — including the sibling ACH source. **Send lowercase.** Every Checkout.com SDK sends lowercase, and this is pending confirmation from the API owners as a likely specification defect. Documented on the attribute.
